### PR TITLE
Fixed FGC modes

### DIFF
--- a/src/modes/FgcMode.cpp
+++ b/src/modes/FgcMode.cpp
@@ -1,7 +1,7 @@
 #include "modes/FgcMode.hpp"
 
 FgcMode::FgcMode(socd::SocdType horizontal_socd, socd::SocdType vertical_socd) {
-    _socd_pair_count = 4;
+    _socd_pair_count = 2;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
         socd::SocdPair{&InputState::left,   &InputState::right, horizontal_socd         },
  /* Mod X override C-Up input if both are pressed. Without this, neutral SOCD doesn't work

--- a/src/modes/FgcModeWASD.cpp
+++ b/src/modes/FgcModeWASD.cpp
@@ -1,7 +1,7 @@
 #include "modes/FgcModeWASD.hpp"
 
 FgcModeWASD::FgcModeWASD(socd::SocdType horizontal_socd, socd::SocdType vertical_socd) {
-    _socd_pair_count = 4;
+    _socd_pair_count = 2;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
         socd::SocdPair{&InputState::left,   &InputState::right, horizontal_socd         },
  /* Mod X override C-Up input if both are pressed. Without this, neutral SOCD doesn't work


### PR DESCRIPTION
Changed `_socd_pair_count` to the correct number of socd pairs to resolve an issue causing the controller to crash upon executing the FGC modes.